### PR TITLE
updated 'fix langevin' with user-input parameters

### DIFF
--- a/src/trimem/mc/trilmp.py
+++ b/src/trimem/mc/trilmp.py
@@ -762,7 +762,7 @@ class TriLmp():
                     bds=f'scale 2 {(self.beads.masses / self.beads.bead_sizes)/sc0} '
 
             lv_thermo_comm=f"""
-                            fix lvt all langevin {self.algo_params.initial_temperature*1} {self.algo_params.initial_temperature*1} 0.03 2 {bds}
+                            fix lvt all langevin {self.algo_params.initial_temperature} {self.algo_params.initial_temperature}  {self.algo_params.langevin_damp} {self.algo_params.langevin_seed} {bds}
                             
                             """
             self.lmp.commands_string(lv_thermo_comm)


### PR DESCRIPTION
The 'fix langevin' line is using hard-coded parameters for the damping (tau = 0.03) and for the seed (seed = 2)