### PR TITLE
remove CM drift in fix langevin

### DIFF
--- a/src/trimem/mc/trilmp.py
+++ b/src/trimem/mc/trilmp.py
@@ -762,7 +762,7 @@ class TriLmp():
                     bds=f'scale 2 {(self.beads.masses / self.beads.bead_sizes)/sc0} '
 
             lv_thermo_comm=f"""
-                            fix lvt all langevin {self.algo_params.initial_temperature} {self.algo_params.initial_temperature}  {self.algo_params.langevin_damp} {self.algo_params.langevin_seed} {bds}
+                            fix lvt all langevin {self.algo_params.initial_temperature} {self.algo_params.initial_temperature}  {self.algo_params.langevin_damp} {self.algo_params.langevin_seed} zero yes {bds}
                             
                             """
             self.lmp.commands_string(lv_thermo_comm)


### PR DESCRIPTION
There seems to be a continuation problem between trajectory snapshots. Incorporated 'zero yes' keywords in the 'fix langevin' to prevent drift of the CM of the system