### PR TITLE
replace ssh in .gitmodules with flexible https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://gitlab.vci.rwth-aachen.de:9000/OpenMesh/OpenMesh.git
 [submodule "lammps"]
 	path = lammps
-	url = git@github.com:lammps/lammps.git
+	url = https://github.com/lammps/lammps.git


### PR DESCRIPTION
As the title says. 

.gitmodules was requiring ssh access to github to install lammps.
It's more flexible to give a generally valid URL and then have the user decide which protocol (ssh or https) to use.

See also this [stackoverflow](https://stackoverflow.com/questions/6031494/git-submodules-and-ssh-access?rq=3) question. 